### PR TITLE
Fix field validation being triggered for each field whenever a field …

### DIFF
--- a/src/useField.tsx
+++ b/src/useField.tsx
@@ -60,7 +60,7 @@ export function useField<T = any, Values = any>(
     validate,
     validateDebounce = false,
     validateOnChangeFields,
-    validateOnChange,
+    validateOnChange = true,
     validateOnBlur,
   } = options
 
@@ -165,8 +165,7 @@ export function useField<T = any, Values = any>(
 
   // validateOnChange
   useEffect(() => {
-    // validate only if explicitely turned on or `validateOnChangeFields` is set.
-    if (validateOnChange !== true && !validateOnChangeFields) {
+    if (!validateOnChange) {
       return
     }
 

--- a/test/Field.test.tsx
+++ b/test/Field.test.tsx
@@ -419,7 +419,61 @@ describe("<Field /> validation", () => {
         </Field>
       ),
       {
-        validateOnChange: true,
+        validateOnChange: false,
+      }
+    )
+
+    form().validate()
+
+    expect(validate).toBeCalledTimes(1)
+  })
+
+  it("field validation is called when submitting form", () => {
+    const validate = jest.fn(() => Promise.resolve(undefined))
+    const { form } = renderTestForm(
+      () => (
+        <Field name="name" validate={validate}>
+          {() => <span />}
+        </Field>
+      ),
+      {
+        validateOnChange: false,
+      }
+    )
+
+    form().submit()
+
+    expect(validate).toBeCalledTimes(1)
+  })
+
+  it("validateOnChange = false does not trigger field validation when field value changes", () => {
+    const validate = jest.fn(() => Promise.resolve(undefined))
+    const { form } = renderTestForm(
+      () => (
+        <Field name="name" validate={validate} validateOnChange={false}>
+          {() => <span />}
+        </Field>
+      ),
+      {
+        validateOnChange: false,
+      }
+    )
+
+    form().setFieldValue("name", "jean")
+
+    expect(validate).toBeCalledTimes(0)
+  })
+
+  it("validateOnChange = true does trigger field validation when field value changes", () => {
+    const validate = jest.fn(() => Promise.resolve(undefined))
+    const { form } = renderTestForm(
+      () => (
+        <Field name="name" validate={validate} validateOnChange={true}>
+          {() => <span />}
+        </Field>
+      ),
+      {
+        validateOnChange: false,
       }
     )
 
@@ -438,11 +492,11 @@ describe("<Field /> validation", () => {
         </Field>
       ),
       {
-        validateOnChange: true,
+        validateOnChange: false,
       }
     )
 
-    form().setFieldValue("name", "jean")
+    form().validate()
 
     expect(validate).toBeCalledTimes(1)
 
@@ -454,7 +508,7 @@ describe("<Field /> validation", () => {
       ),
     })
 
-    form().setFieldValue("name", "jean2")
+    form().validate()
 
     expect(validate).toBeCalledTimes(1)
     expect(validate2).toBeCalledTimes(1)
@@ -471,12 +525,12 @@ describe("<Field /> validation", () => {
         </Field>
       ),
       {
-        validateOnChange: true,
+        validateOnChange: false,
       }
     )
 
     const field = injectedField!
-    field.setValue("jean")
+    field.validate()
 
     await waitForExpect(() => {
       expect(field.error).toEqual({ message: "Error!" })
@@ -494,12 +548,12 @@ describe("<Field /> validation", () => {
         </Field>
       ),
       {
-        validateOnChange: true,
+        validateOnChange: false,
       }
     )
 
     const field = injectedField!
-    field.setValue("jean")
+    field.validate()
 
     await waitForExpect(() => {
       expect(field.error).toEqual({ message: "Uh oh!" })
@@ -571,7 +625,7 @@ describe("<Field /> validation", () => {
     expect(field.error).toEqual(error![0])
   })
 
-  it("validateOnChange is off by default", async () => {
+  it("validateOnChange is on by default", async () => {
     let injectedField: FieldRenderProps | undefined = undefined
     const validate = jest.fn(() => Promise.resolve("Error!"))
 
@@ -591,7 +645,7 @@ describe("<Field /> validation", () => {
     const field = injectedField!
     field.setValue("Jim")
 
-    expect(validate).toBeCalledTimes(0)
+    expect(validate).toBeCalledTimes(1)
   })
 
   it("validateOnChange", async () => {
@@ -747,14 +801,14 @@ describe("<Field /> validation", () => {
     }
 
     const { form, rerender } = renderForm(() => renderNameField(), {
-      initialValues: { name: "chuck", surname: "norris" },
+      initialValues: { name: "chuck", surname: "norris", age: 40 },
       validateOnChange: false,
       validateOnBlur: false,
     })
 
     form().setFieldValue("name", "jackie")
 
-    expect(validate).toBeCalledTimes(0)
+    expect(validate).toBeCalledTimes(1)
 
     rerender({
       ui: () => renderNameField(["surname"]),
@@ -764,11 +818,15 @@ describe("<Field /> validation", () => {
 
     form().setFieldValue("name", "bill")
 
-    expect(validate).toBeCalledTimes(1)
+    expect(validate).toBeCalledTimes(2)
 
     form().setFieldValue("surname", "murray")
 
-    expect(validate).toBeCalledTimes(2)
+    expect(validate).toBeCalledTimes(3)
+
+    form().setFieldValue("age", 25)
+
+    expect(validate).toBeCalledTimes(3)
   })
 
   it("validateOnChangeFields should respect <FieldScope />", async () => {

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -22,6 +22,7 @@ const InitialValues = {
 
 function renderTestForm(props: FormConfig = {}) {
   let renderNameCount = 0
+  let renderSurnameCount = 0
 
   const result = renderForm(
     () => {
@@ -37,28 +38,31 @@ function renderTestForm(props: FormConfig = {}) {
                     {...field.input}
                     data-testid="name-input"
                   />
-                  {field.isTouched && field.error?.message}
+                  {field.error?.message}
                 </div>
               )
             }}
           </Field>
           <Field name="surname">
-            {(field) => (
-              <div>
-                <input
-                  type="text"
-                  {...field.input}
-                  data-testid="surname-input"
-                />
-                {field.isTouched && field.error?.message}
-              </div>
-            )}
+            {(field) => {
+              renderSurnameCount++
+              return (
+                <div>
+                  <input
+                    type="text"
+                    {...field.input}
+                    data-testid="surname-input"
+                  />
+                  {field.error?.message}
+                </div>
+              )
+            }}
           </Field>
           <Field name="preferences.color">
             {(field) => (
               <div>
                 <input type="text" {...field.input} data-testid="color-input" />
-                {field.isTouched && field.error?.message}
+                {field.error?.message}
               </div>
             )}
           </Field>
@@ -102,6 +106,9 @@ function renderTestForm(props: FormConfig = {}) {
     ...result,
     renderNameCount() {
       return renderNameCount
+    },
+    renderSurnameCount() {
+      return renderSurnameCount
     },
   }
 }
@@ -154,16 +161,21 @@ describe("useForm", () => {
     expect(getInputValue("friend-age-input")).toEqual("42")
   })
 
-  it("rerenders only the input", () => {
-    const { form, renderCount, renderNameCount } = renderTestForm()
+  it("rerenders only the input", async () => {
+    const { form, renderCount, renderNameCount, renderSurnameCount } =
+      renderTestForm()
 
     expect(renderCount()).toBe(1)
     expect(renderNameCount()).toEqual(1)
+    expect(renderSurnameCount()).toEqual(1)
 
     form().setFieldValue("name", "jean")
 
+    await wait(200) // waiting for validation
+
     expect(renderCount()).toEqual(1)
     expect(renderNameCount()).toEqual(2)
+    expect(renderSurnameCount()).toEqual(1)
   })
 
   it("handles field touched", () => {


### PR DESCRIPTION
…was changed

Field validation occurs:
- when that field is changed (if validateOnChange is true - by default)
- when other fields changed (only if validateOnChangeFields is populated)
- when that field is touched (if validateOnBlur is true)
- before submitting the form